### PR TITLE
Allow jasmine to finish

### DIFF
--- a/lib/jasmine.karma.worker.js
+++ b/lib/jasmine.karma.worker.js
@@ -39,7 +39,11 @@
 
     const execute = async function () {
         await jasmineEnv.execute();
-        self.postMessage({event: "reportRunnerResults"});
+        // This doesn't actually wait for jasmine to finish.
+        // I don't know a way to run something when jasmine finishes running tests.
+        // Commenting this for now because it runs before the tests are done
+        // and results in karma stopping the headless browser.
+        // self.postMessage({event: "reportRunnerResults"});
     }
 
     execute();


### PR DESCRIPTION
This change will allow jasmine to finish running tests. The current behavior sends a message to Karma indicating that the tests are done while they are not. That message results in Karma stopping the headless browser while tests were not done yet.